### PR TITLE
Use gridField getState method to ensure that the state is initialised…

### DIFF
--- a/src/PersistentGridField.php
+++ b/src/PersistentGridField.php
@@ -204,7 +204,7 @@ class PersistentGridField extends GridField
         $stateHash = $this->getStateHash();
 
         if ($previousState = Controller::curr()->getRequest()->getSession()->get($stateHash)) {
-            $this->state->setValue($previousState);
+            $this->getState(false)->setValue($previousState);
         }
 
         return parent::FieldHolder($properties);


### PR DESCRIPTION
The GridField state is no longer initialised within the constructor since Silverstripe Framework 4.8.1 (see https://github.com/silverstripe/silverstripe-framework/commit/70ffb3297acd1e281d8246bb26878a2e35d530fe#diff-c5907f790efc160f18abbccf8d6d3de8e13eff90e5b3a6119e1447da06f70c40) which causes the error reported in #7.

So to ensure that the state is initialised before trying to restore the previous state, we have to use the getState() method instead of directly accessing the state property.