### PR TITLE
Init default state if method exists

### DIFF
--- a/src/PersistentGridField.php
+++ b/src/PersistentGridField.php
@@ -161,7 +161,12 @@ class PersistentGridField extends GridField
                 $actionName = $stateChange['actionName'];
                 if ($actionName === 'ResetState') {
                     $session->set($stateHash, null);
-                    $this->state = new GridState($this);
+                    if (method_exists($this, 'initState')) {
+                        $this->state = null;
+                        $this->getState(false);
+                    } else {
+                        $this->state = new GridState($this);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #9 

### Summary
Init default state if method exists. Prevents error when resetting grid state.

### Testing
- [ ] test with the updated framework
- [ ] reset a persistent gridfield
- [ ] confirm no alert shows with a notice in the network inspector